### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.1.3: QmauYrW3kDcfZwUuqjyDCSTyaicL8tvo3a7VkAVgAEes96
+2.1.4: QmXcN1kXchSvodd2MGypWXXirXk7GigQ7WVyWGYpukag6J

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "Qme2XMfKbWzzYd92YvA1qnFMe3pGDR86j5BcFtx4PwdRvr",
+      "hash": "QmQGRkVSA5vTXt9WpJ6nBGnrvq9zRNsfjoNPq8uQrhnBoq",
       "name": "go-libp2p-transport",
-      "version": "2.2.9"
+      "version": "2.2.10"
     }
   ],
   "gxVersion": "0.9.1",
@@ -20,6 +20,6 @@
   "license": "MIT",
   "name": "go-libp2p-interface-pnet",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "2.1.3"
+  "version": "2.1.4"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4
- https://github.com/libp2p/go-ws-transport/pull/28
- https://github.com/libp2p/go-addr-util/pull/9
- https://github.com/ipfs/go-cid/pull/39
- https://github.com/libp2p/go-testutil/pull/15
- https://github.com/libp2p/go-libp2p-interface-conn/pull/4


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace